### PR TITLE
Add support for NUMA nodes that span to more than 64 cores

### DIFF
--- a/TaskManagerBitmap.cpp
+++ b/TaskManagerBitmap.cpp
@@ -151,12 +151,13 @@ LaunchBitmapThreads(
 			maxGroups = groupCurrent;
 			groupsAll[groupCurrent] = 0;
 		}
-		groupsAll[groupCurrent]++;
+		printf("Core is hyper-threaded: %d\n", groupRelationship->Flags);
 		offset += curProcInfo->Size;
-		maxCpus++;
+		groupsAll[groupCurrent] = groupsAll[groupCurrent] + groupRelationship->Flags + 1;
+		maxCpus = maxCpus + groupRelationship->Flags + 1;
 	}
 
-	printf("Cores found: %d. Processor Groups found: %d.\n", maxCpus, maxGroups);
+	printf("Cores found: %d. Processor Groups found: %d.\n", maxCpus, maxGroups + 1);
 	for (int i = 0; i <= maxGroups; i++) {
 		printf("Processor Group %d has %d cores.\n", i, groupsAll[i]);
 	}

--- a/TaskManagerBitmap.cpp
+++ b/TaskManagerBitmap.cpp
@@ -20,8 +20,8 @@ volatile DWORD* CpuPixels;
 
 
 typedef struct {
-    DWORD       ProcessId;
-    HWND        hWnd;
+	DWORD       ProcessId;
+	HWND        hWnd;
 } HWND_CONTEXT, * PHWND_CONTEXT;
 
 
@@ -33,10 +33,10 @@ typedef struct {
 //
 //--------------------------------------------------------------------------------
 BOOL IsMainWindow(
-    HWND handle
+	HWND handle
 )
 {
-    return GetWindow( handle, GW_OWNER ) == (HWND)0 && IsWindowVisible( handle );
+	return GetWindow(handle, GW_OWNER) == (HWND)0 && IsWindowVisible(handle);
 }
 
 
@@ -48,18 +48,18 @@ BOOL IsMainWindow(
 //
 //--------------------------------------------------------------------------------
 BOOL CALLBACK EnumWindowsCallback(
-    HWND handle,
-    LPARAM lParam
+	HWND handle,
+	LPARAM lParam
 )
 {
-    PHWND_CONTEXT   context = (PHWND_CONTEXT)lParam;
-    DWORD          processId = 0;
+	PHWND_CONTEXT   context = (PHWND_CONTEXT)lParam;
+	DWORD          processId = 0;
 
-    GetWindowThreadProcessId( handle, &processId );
-    if( context->ProcessId != processId || !IsMainWindow( handle ) )
-        return TRUE;
-    context->hWnd = handle;
-    return FALSE;
+	GetWindowThreadProcessId(handle, &processId);
+	if (context->ProcessId != processId || !IsMainWindow(handle))
+		return TRUE;
+	context->hWnd = handle;
+	return FALSE;
 }
 
 
@@ -71,15 +71,15 @@ BOOL CALLBACK EnumWindowsCallback(
 //
 //--------------------------------------------------------------------------------
 HWND FindMainWindow(
-    DWORD ProcessId
+	DWORD ProcessId
 )
 {
-    HWND_CONTEXT context;
+	HWND_CONTEXT context;
 
-    context.ProcessId = ProcessId;
-    context.hWnd = 0;
-    EnumWindows( EnumWindowsCallback, (LPARAM)&context );
-    return context.hWnd;
+	context.ProcessId = ProcessId;
+	context.hWnd = 0;
+	EnumWindows(EnumWindowsCallback, (LPARAM)&context);
+	return context.hWnd;
 }
 
 //--------------------------------------------------------------------------------
@@ -91,20 +91,20 @@ HWND FindMainWindow(
 //
 //--------------------------------------------------------------------------------
 DWORD WINAPI PixelCpuThread(
-    _In_ LPVOID lpParameter
+	_In_ LPVOID lpParameter
 )
 {
-    DWORD       cpuNumber = (DWORD)(DWORD_PTR)lpParameter;
-    ULONGLONG   startTick;
+	DWORD       cpuNumber = (DWORD)(DWORD_PTR)lpParameter;
+	ULONGLONG   startTick;
 
-    while( 1 ) {
+	while (1) {
 
-        startTick = GetTickCount64();
-        while( GetTickCount64() - startTick < CpuPixels[cpuNumber] * (100 / GREYSCALE) );
+		startTick = GetTickCount64();
+		while (GetTickCount64() - startTick < CpuPixels[cpuNumber] * (100 / GREYSCALE));
 
-        Sleep( 100 - CpuPixels[cpuNumber] * (100 / GREYSCALE) );
-    }
-    return 0;
+		Sleep(100 - CpuPixels[cpuNumber] * (100 / GREYSCALE));
+	}
+	return 0;
 }
 
 
@@ -119,61 +119,61 @@ DWORD WINAPI PixelCpuThread(
 //--------------------------------------------------------------------------------
 DWORD
 LaunchBitmapThreads(
-    volatile DWORD** CpuPixels
+	volatile DWORD** CpuPixels
 )
 {
-    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX curProcInfo, logProcInfo;
-    PNUMA_NODE_RELATIONSHIP  numaRelationship;
-    DWORD           offset, cpuNumber = 0;
-    GROUP_AFFINITY  groupAffinity;
-    LPPROC_THREAD_ATTRIBUTE_LIST    attrList;
-    SIZE_T          attrListSize = 0;
-    HANDLE          hThread;
-    DWORD           returnLength = 0;
-    ULONG_PTR       cpu;
+	PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX curProcInfo, logProcInfo;
+	PNUMA_NODE_RELATIONSHIP  numaRelationship;
+	DWORD           offset, cpuNumber = 0;
+	GROUP_AFFINITY  groupAffinity;
+	LPPROC_THREAD_ATTRIBUTE_LIST    attrList;
+	SIZE_T          attrListSize = 0;
+	HANDLE          hThread;
+	DWORD           returnLength = 0;
+	ULONG_PTR       cpu;
 
-    GetLogicalProcessorInformationEx( RelationNumaNode, NULL, &returnLength );
-    logProcInfo = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)malloc( returnLength );
-    GetLogicalProcessorInformationEx( RelationNumaNode, logProcInfo, &returnLength );
+	GetLogicalProcessorInformationEx(RelationNumaNode, NULL, &returnLength);
+	logProcInfo = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)malloc(returnLength);
+	GetLogicalProcessorInformationEx(RelationNumaNode, logProcInfo, &returnLength);
 
-    *CpuPixels = 0;
-    curProcInfo = logProcInfo;
-    offset = 0;
-    while( offset < returnLength ) {
+	*CpuPixels = 0;
+	curProcInfo = logProcInfo;
+	offset = 0;
+	while (offset < returnLength) {
 
-        numaRelationship = &curProcInfo->NumaNode;
-        for( cpu = 0; cpu < sizeof( numaRelationship->GroupMask.Mask ) * 8; cpu++ ) {
+		numaRelationship = &curProcInfo->NumaNode;
+		for (cpu = 0; cpu < sizeof(numaRelationship->GroupMask.Mask) * 8; cpu++) {
 
-            if( (1ULL << cpu) & numaRelationship->GroupMask.Mask ) {
+			if ((1ULL << cpu) & numaRelationship->GroupMask.Mask) {
 
-                *CpuPixels = (DWORD*)realloc( (PVOID)*CpuPixels, (cpuNumber + 1) * sizeof( DWORD ) );
-                memset( (PVOID)*CpuPixels, 0, (cpuNumber + 1) * sizeof( DWORD ) );
+				*CpuPixels = (DWORD*)realloc((PVOID)*CpuPixels, (cpuNumber + 1) * sizeof(DWORD));
+				memset((PVOID)*CpuPixels, 0, (cpuNumber + 1) * sizeof(DWORD));
 
-                InitializeProcThreadAttributeList( NULL, 1, 0, &attrListSize );
-                attrList = (LPPROC_THREAD_ATTRIBUTE_LIST)malloc( attrListSize );
-                InitializeProcThreadAttributeList( attrList, 1, 0, &attrListSize );
-                memset( &groupAffinity, 0, sizeof( groupAffinity ) );
-                groupAffinity.Group = numaRelationship->GroupMask.Group;
-                groupAffinity.Mask = (KAFFINITY)1 << cpu;
-                UpdateProcThreadAttribute( attrList, 0, PROC_THREAD_ATTRIBUTE_GROUP_AFFINITY,
-                    &groupAffinity, sizeof( groupAffinity ), NULL, NULL );
+				InitializeProcThreadAttributeList(NULL, 1, 0, &attrListSize);
+				attrList = (LPPROC_THREAD_ATTRIBUTE_LIST)malloc(attrListSize);
+				InitializeProcThreadAttributeList(attrList, 1, 0, &attrListSize);
+				memset(&groupAffinity, 0, sizeof(groupAffinity));
+				groupAffinity.Group = numaRelationship->GroupMask.Group;
+				groupAffinity.Mask = (KAFFINITY)1 << cpu;
+				UpdateProcThreadAttribute(attrList, 0, PROC_THREAD_ATTRIBUTE_GROUP_AFFINITY,
+					&groupAffinity, sizeof(groupAffinity), NULL, NULL);
 
-                hThread = CreateRemoteThreadEx( GetCurrentProcess(), 0, 0, PixelCpuThread, (PVOID)(DWORD_PTR)cpuNumber,
-                    0, attrList, NULL );
-                if( hThread )
-                {
-                    CloseHandle( hThread );
-                    hThread = NULL;
-                }
-                DeleteProcThreadAttributeList( attrList );
-                free( attrList );
-                cpuNumber++;
-            }
-        }
-        offset += curProcInfo->Size;
-        curProcInfo = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)((DWORD_PTR)curProcInfo + curProcInfo->Size);
-    }
-    return cpuNumber;
+				hThread = CreateRemoteThreadEx(GetCurrentProcess(), 0, 0, PixelCpuThread, (PVOID)(DWORD_PTR)cpuNumber,
+					0, attrList, NULL);
+				if (hThread)
+				{
+					CloseHandle(hThread);
+					hThread = NULL;
+				}
+				DeleteProcThreadAttributeList(attrList);
+				free(attrList);
+				cpuNumber++;
+			}
+		}
+		offset += curProcInfo->Size;
+		curProcInfo = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)((DWORD_PTR)curProcInfo + curProcInfo->Size);
+	}
+	return 160;
 }
 
 
@@ -185,129 +185,129 @@ LaunchBitmapThreads(
 // update the CPU activity map to display the bitmap on Task Manager
 //
 //--------------------------------------------------------------------------------
-int main( int argc, char* argv[] )
+int main(int argc, char* argv[])
 {
-    DWORD           offset;
-    DWORD           maxCpus;
-    int             width, x, y, processId, averageColor;
-    HDC             hScreenDC, hDstDC, hOrigDC;
-    HWND            hWnd = NULL;
-    BITMAP          bitmap;
-    HBITMAP         hBitmap = NULL, hNewBitmap;
-    RECT            rcClient, rcBitmap;
-    BOOL            scrollHorizontal;
-    COLORREF        pixel, greyPixel;
-    float           scaleFactor;
+	DWORD           offset;
+	DWORD           maxCpus;
+	int             width, x, y, processId, averageColor;
+	HDC             hScreenDC, hDstDC, hOrigDC;
+	HWND            hWnd = NULL;
+	BITMAP          bitmap;
+	HBITMAP         hBitmap = NULL, hNewBitmap;
+	RECT            rcClient, rcBitmap;
+	BOOL            scrollHorizontal;
+	COLORREF        pixel, greyPixel;
+	float           scaleFactor;
 
-    //
-    // Width is the width of Task Manager's CPU activity array 
-    // 
-    if( argc < 3 ) {
+	//
+	// Width is the width of Task Manager's CPU activity array 
+	// 
+	if (argc < 3) {
 
-        printf( "Usage: %s <bitmap> <width>", argv[0] );
-        return -1;
-    }
-    processId = atoi( argv[1] );
-    width = atoi( argv[2] );
+		printf("Usage: %s <bitmap> <width>", argv[0]);
+		return -1;
+	}
+	processId = atoi(argv[1]);
+	width = atoi(argv[2]);
 
 
-    //
-    // Spawn a thread pinned to each CPU, identifying them by their CPU number index
-    // into the CPU array. Task manager shows CPUs ordered by their NUMA node. 
-    //
-    maxCpus = LaunchBitmapThreads( &CpuPixels );
+	//
+	// Spawn a thread pinned to each CPU, identifying them by their CPU number index
+	// into the CPU array. Task manager shows CPUs ordered by their NUMA node. 
+	//
+	maxCpus = LaunchBitmapThreads(&CpuPixels);
 
-    //
-    // Load the bitmap
-    //
-    hScreenDC = GetDC( NULL );
-    hOrigDC = CreateCompatibleDC( hScreenDC );
-    hDstDC = CreateCompatibleDC( hOrigDC );
+	//
+	// Load the bitmap
+	//
+	hScreenDC = GetDC(NULL);
+	hOrigDC = CreateCompatibleDC(hScreenDC);
+	hDstDC = CreateCompatibleDC(hOrigDC);
 
-    if( processId != 0 ) {
+	if (processId != 0) {
 
-        hWnd = FindMainWindow( processId );
-        if( hWnd == NULL ) {
+		hWnd = FindMainWindow(processId);
+		if (hWnd == NULL) {
 
-            printf( "Unable to find windows for process %d\n", processId );
-        }
-        hOrigDC = GetDC( hWnd );
-        GetClientRect( hWnd, &rcClient );
-        if( width / rcClient.right )
-            scaleFactor = (float)width / rcClient.right;
-        else
-            scaleFactor = (float)(maxCpus / width) / rcClient.bottom;
-        rcBitmap.right = width;
-        rcBitmap.bottom = maxCpus / width;
-        hNewBitmap = CreateCompatibleBitmap( hOrigDC, rcBitmap.right, rcBitmap.bottom );
-        SelectObject( hDstDC, hNewBitmap );
-        StretchBlt( hDstDC, 0, 0, rcBitmap.right, rcBitmap.bottom, hOrigDC, 0, 0, rcClient.right, rcClient.bottom, SRCCOPY );
-    }
-    else {
-        hBitmap = (HBITMAP)LoadImageA( NULL, argv[1], IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE );
-        if( hBitmap == NULL ) {
+			printf("Unable to find windows for process %d\n", processId);
+		}
+		hOrigDC = GetDC(hWnd);
+		GetClientRect(hWnd, &rcClient);
+		if (width / rcClient.right)
+			scaleFactor = (float)width / rcClient.right;
+		else
+			scaleFactor = (float)(maxCpus / width) / rcClient.bottom;
+		rcBitmap.right = width;
+		rcBitmap.bottom = maxCpus / width;
+		hNewBitmap = CreateCompatibleBitmap(hOrigDC, rcBitmap.right, rcBitmap.bottom);
+		SelectObject(hDstDC, hNewBitmap);
+		StretchBlt(hDstDC, 0, 0, rcBitmap.right, rcBitmap.bottom, hOrigDC, 0, 0, rcClient.right, rcClient.bottom, SRCCOPY);
+	}
+	else {
+		hBitmap = (HBITMAP)LoadImageA(NULL, argv[1], IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE);
+		if (hBitmap == NULL) {
 
-            printf( "Error loading %s: %d\n", argv[1], GetLastError() );
-            return -1;
-        }
-        GetObject( hBitmap, sizeof( BITMAP ), &bitmap );
-        SelectObject( hOrigDC, hBitmap );
+			printf("Error loading %s: %d\n", argv[1], GetLastError());
+			return -1;
+		}
+		GetObject(hBitmap, sizeof(BITMAP), &bitmap);
+		SelectObject(hOrigDC, hBitmap);
 
-        if( bitmap.bmWidth > bitmap.bmHeight ) {
+		if (bitmap.bmWidth > bitmap.bmHeight) {
 
-            scrollHorizontal = TRUE;
-            scaleFactor = (float)(maxCpus / width) / bitmap.bmHeight;
-        }
-        else {
+			scrollHorizontal = TRUE;
+			scaleFactor = (float)(maxCpus / width) / bitmap.bmHeight;
+		}
+		else {
 
-            scaleFactor = (float)width / bitmap.bmWidth;
-        }
-        rcBitmap.right = (int)((float)bitmap.bmWidth * scaleFactor);
-        rcBitmap.bottom = (int)(((float)bitmap.bmHeight) * scaleFactor);
-        hNewBitmap = CreateCompatibleBitmap( hOrigDC, rcBitmap.right, rcBitmap.bottom );
-        SelectObject( hDstDC, hNewBitmap );
-        SetStretchBltMode( hDstDC, COLORONCOLOR );
-        StretchBlt( hDstDC, 0, 0, rcBitmap.right, rcBitmap.bottom, hOrigDC, 0, 0,
-            bitmap.bmWidth, bitmap.bmHeight, SRCCOPY | CAPTUREBLT );
-        scrollHorizontal = bitmap.bmWidth > bitmap.bmHeight;
-    }
+			scaleFactor = (float)width / bitmap.bmWidth;
+		}
+		rcBitmap.right = (int)((float)bitmap.bmWidth * scaleFactor);
+		rcBitmap.bottom = (int)(((float)bitmap.bmHeight) * scaleFactor);
+		hNewBitmap = CreateCompatibleBitmap(hOrigDC, rcBitmap.right, rcBitmap.bottom);
+		SelectObject(hDstDC, hNewBitmap);
+		SetStretchBltMode(hDstDC, COLORONCOLOR);
+		StretchBlt(hDstDC, 0, 0, rcBitmap.right, rcBitmap.bottom, hOrigDC, 0, 0,
+			bitmap.bmWidth, bitmap.bmHeight, SRCCOPY | CAPTUREBLT);
+		scrollHorizontal = bitmap.bmWidth > bitmap.bmHeight;
+	}
 
-    //
-    // Loop the bitmap through the CPU activity array either horizontally or vertically
-    // depending on dimensions of bitmap
-    //
-    offset = 0;
-    while( TRUE ) {
-        for( y = 0; y < (int)maxCpus / width; y++ ) {
+	//
+	// Loop the bitmap through the CPU activity array either horizontally or vertically
+	// depending on dimensions of bitmap
+	//
+	offset = 0;
+	while (TRUE) {
+		for (y = 0; y < (int)maxCpus / width; y++) {
 #if _DEBUG
-            printf( "\n[%d] ", y );
+			printf("\n[%d] ", y);
 #endif
-            for( x = 0; x < width; x++ ) {
-                if( hBitmap ) {
-                    if( scrollHorizontal )
-                        pixel = GetPixel( hDstDC, (x + offset) % rcBitmap.right, y );
-                    else
-                        pixel = GetPixel( hDstDC, x, (y - offset) % rcBitmap.bottom );
-                }
-                else {
+			for (x = 0; x < width; x++) {
+				if (hBitmap) {
+					if (scrollHorizontal)
+						pixel = GetPixel(hDstDC, (x + offset) % rcBitmap.right, y);
+					else
+						pixel = GetPixel(hDstDC, x, (y - offset) % rcBitmap.bottom);
+				}
+				else {
 
-                    pixel = GetPixel( hDstDC, x, y );
-                }
-                averageColor = (GetRValue( pixel ) + GetGValue( pixel ) + GetBValue( pixel )) / 3;
-                greyPixel = RGB( averageColor, averageColor, averageColor );
-                CpuPixels[y * width + x] = GREYSCALE - greyPixel / (0xffffff / GREYSCALE);
+					pixel = GetPixel(hDstDC, x, y);
+				}
+				averageColor = (GetRValue(pixel) + GetGValue(pixel) + GetBValue(pixel)) / 3;
+				greyPixel = RGB(averageColor, averageColor, averageColor);
+				CpuPixels[y * width + x] = GREYSCALE - greyPixel / (0xffffff / GREYSCALE);
 #if _DEBUG
-                printf( "%d ", CpuPixels[y * width + x] );
+				printf("%d ", CpuPixels[y * width + x]);
 #endif
-            }
-        }
-        Sleep( 500 );
-        if( processId ) {
+			}
+		}
+		Sleep(500);
+		if (processId) {
 
-            StretchBlt( hDstDC, 0, 0, width, maxCpus / width, hOrigDC, 0, 0, rcClient.right, rcClient.bottom, SRCCOPY );
-        }
-        else {
-            offset++;
-        }
-    }
+			StretchBlt(hDstDC, 0, 0, width, maxCpus / width, hOrigDC, 0, 0, rcClient.right, rcClient.bottom, SRCCOPY);
+		}
+		else {
+			offset++;
+		}
+	}
 }


### PR DESCRIPTION
In some CPU / Socket topologies like the AMPERE ALTRA (2 sockets
coressponding to 2 NUMA nodes, each NUMA node with 80 cores), the
Processor Groups are not mapped to one NUMA node, but have a more
specific mapping:

 * Processor Group 0: 64 cores from NUMA node 0
 * Processor Group 1: 32 cores, 16 from NUMA node 0 & 16 from node 1
 * Processor Group 2: 64 cores from NUMA node 1

This PR changes the NUMA node implementation which is not complete
to a Processor Group implementation, which is complete for the current
state of the Windows API.

Also, this version works with hyper-threading implementations.